### PR TITLE
Fixes Array.filter ES5 mootools/mootools-core#2169.

### DIFF
--- a/es5/array.js
+++ b/es5/array.js
@@ -8,8 +8,9 @@ var array = require("../util/shell")().implement({
 
 	filter: proto.filter/*(es5 && array.filter)?*/ || function(fn, context){
 		var results = []
-		for (var i = 0, l = this.length >>> 0; i < l; i++){
-			if ((i in this) && fn.call(context, this[i], i, this)) results.push(this[i])
+		for (var i = 0, l = this.length >>> 0; i < l; i++) if (i in this){
+			var value = this[i]
+			if (fn.call(context, value, i, this)) results.push(value)
 		}
 		return results
 	}/*:*/,

--- a/test/es5/array.js
+++ b/test/es5/array.js
@@ -1,8 +1,18 @@
+"use strict";
 
 var expect = require('expect.js')
 var array = require('../../es5/array')
 
 describe('es5/array', function(){
+
+	it('should accept thisArgs without length property', function(){
+		var object = {}, fn = function(){}
+		expect([].every.call(object, fn)).to.be(true)
+		expect([].filter.call(object, fn)).to.eql([])
+		expect([].indexOf.call(object)).to.equal(-1)
+		expect([].map.call(object, fn)).to.eql([])
+		expect([].some.call(object, fn)).to.be(false)
+	})
 
 	describe('Array.isArray', function(){
 
@@ -55,6 +65,18 @@ describe('es5/array', function(){
 			expect(i).to.equal(2)
 		})
 
+		it('should return the original item, and not any mutations.', function(){
+
+			var result = [0, 1, 2].filter(function(num, i, array){
+				if (num == 1){
+					array[i] = 'mutation'
+					return true
+				}
+			})
+
+			expect(result[0]).to.equal(1)
+		})
+
 	})
 
 	describe('Array.indexOf', function(){
@@ -86,6 +108,18 @@ describe('es5/array', function(){
 			})
 
 			expect(i).to.equal(2)
+		})
+
+		it('should return an array with the same length', function(){
+			expect([1, 2, 3, undefined].map(function(v){
+				return v
+			}).length).to.equal(4);
+		})
+
+		it('shoud return an empty array when the thisArg does not has a length property', function(){
+			expect([].map.call({}, function(){
+				return 1
+			})).to.eql([])
 		})
 
 	})


### PR DESCRIPTION
As per spec, `Array.filter` should return the filtered items, and not
andany possible mutation that might have occurred in the callback. See
referenced issue for more information.

Added coverage for case.
