### PR TITLE
Fixes #2 - Array.indexOf should skip deleted items in sparse arrays.

### DIFF
--- a/es5/array.js
+++ b/es5/array.js
@@ -19,7 +19,7 @@ var array = shell({
 
 	indexOf: proto.indexOf/*(es5 && array.indexOf)?*/ || function(item, from){
 		for (var l = this.length >>> 0, i = (from < 0) ? Math.max(0, l + from) : from || 0; i < l; i++){
-			if (this[i] === item) return i
+			if ((i in this) && this[i] === item) return i
 		}
 		return -1
 	}/*:*/,

--- a/test/es5/array.js
+++ b/test/es5/array.js
@@ -89,6 +89,10 @@ describe('es5/array', function(){
 			expect(array.indexOf([1,2,3,0,0,0], 'not found')).to.equal(-1)
 		})
 
+		it('should return -1 for undefined when the array is sparse', function(){
+			expect(array.indexOf(new Array(4), undefined)).to.equal(-1)
+		})
+
 	})
 
 	describe('Array.map', function(){


### PR DESCRIPTION
See #2.
