### PR TITLE
requestAnimationFrame passes a DOMHighResTimeStamp, polyfilling it

### DIFF
--- a/defer.js
+++ b/defer.js
@@ -89,7 +89,9 @@ var requestAnimationFrame = global.requestAnimationFrame ||
     global.oRequestAnimationFrame ||
     global.msRequestAnimationFrame ||
     function(callback) {
-        setTimeout(callback, 1e3 / 60)
+        setTimeout(function(){
+            callback(+new Date())
+        }, 1e3 / 60)
     }
 
 defer.frame = function(callback, context){


### PR DESCRIPTION
rAF passes a DOMHighResTimeStamp (Performance.now()) or a DOMTimeStamp
(Date.now()) if the prefixed version is used,
since Performance.now() is not available, either using Date.now() or
+new Date() should be enough, last one is known to work in any
browser/server, so seems the best choice here even if it may be slower
